### PR TITLE
feat: save to json file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2890,6 +2890,8 @@ dependencies = [
  "reth-network",
  "reth-primitives",
  "secp256k1",
+ "serde",
+ "serde_json",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,7 @@ reth-network = { git = "https://github.com/paradigmxyz/reth.git", tag = "v0.1.0-
 reth-discv4 = { git = "https://github.com/paradigmxyz/reth.git", tag = "v0.1.0-alpha.10" }
 reth-eth-wire = { git = "https://github.com/paradigmxyz/reth.git", tag = "v0.1.0-alpha.10" }
 reth-ecies = { git = "https://github.com/paradigmxyz/reth.git", tag = "v0.1.0-alpha.10" }
+
+# Serialization
+serde_json = "1.0"
+serde = { version = "1.0.188", features = ["derive"] }


### PR DESCRIPTION
This PR adds the functionality to save newly found peers to a json file in append mode.

A new line for every new peer. This is just a super quick way to have a preview of our crawler.

Right now the information that it saves to file are derived from this struct:
```rust
#[derive(Serialize, Deserialize)]
struct PeerData {
    address: String,
    tcp_port: u16,
    client_version: String,
    eth_version: u8,
}
```