### PR TITLE
(feat) add tcp listener to network for incoming connections, handle too-many-peers after this

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4286,6 +4286,7 @@ dependencies = [
  "reth-eth-wire",
  "reth-network",
  "reth-primitives",
+ "reth-provider",
  "secp256k1 0.27.0",
  "serde",
  "serde_json",
@@ -4674,6 +4675,7 @@ name = "reth-provider"
 version = "0.1.0-alpha.10"
 source = "git+https://github.com/0xprames/reth.git?branch=discv4-recv-preempt#6844a95efd9e86ee9dd197377a431ade87bd5426"
 dependencies = [
+ "alloy-rlp",
  "auto_impl",
  "itertools 0.11.0",
  "parking_lot 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ reth-discv4 = { git = "https://github.com/0xprames/reth.git", branch = "discv4-r
 reth-dns-discovery = { git = "https://github.com/0xprames/reth.git", branch = "discv4-recv-preempt" }
 reth-eth-wire = { git = "https://github.com/0xprames/reth.git", branch = "discv4-recv-preempt" }
 reth-ecies = { git = "https://github.com/0xprames/reth.git", branch = "discv4-recv-preempt" }
+reth-provider = { git = "https://github.com/0xprames/reth.git", branch = "discv4-recv-preempt", features = ["test-utils"] }
 
 # serialization
 serde_json = "1.0"

--- a/bins/reth-crawler/Cargo.toml
+++ b/bins/reth-crawler/Cargo.toml
@@ -15,6 +15,7 @@ reth-discv4.workspace = true
 reth-dns-discovery.workspace = true
 reth-eth-wire.workspace = true
 reth-ecies.workspace = true
+reth-provider.workspace = true
 
 # Serialization
 serde_json.workspace = true

--- a/bins/reth-crawler/src/crawler/factory.rs
+++ b/bins/reth-crawler/src/crawler/factory.rs
@@ -1,10 +1,13 @@
 use once_cell::sync::Lazy;
 use reth_discv4::{Discv4, Discv4ConfigBuilder, DEFAULT_DISCOVERY_ADDRESS};
 use reth_dns_discovery::{
-    DnsDiscoveryConfig, DnsDiscoveryHandle, DnsDiscoveryService, DnsNodeRecordUpdate, DnsResolver,
+    DnsDiscoveryConfig, DnsDiscoveryHandle, DnsDiscoveryService, DnsResolver,
 };
+
 use reth_network::config::rng_secret_key;
+use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, PeersConfig};
 use reth_primitives::{mainnet_nodes, NodeRecord};
+use reth_provider::test_utils::NoopProvider;
 use secp256k1::SecretKey;
 use std::sync::Arc;
 use std::time::Duration;
@@ -17,6 +20,7 @@ pub struct CrawlerFactory {
     key: SecretKey,
     discv4: Discv4,
     dnsdisc: DnsDiscoveryHandle,
+    network: NetworkHandle,
 }
 
 impl CrawlerFactory {
@@ -30,8 +34,21 @@ impl CrawlerFactory {
             .add_boot_nodes(MAINNET_BOOT_NODES.clone())
             .lookup_interval(Duration::from_secs(3));
 
-        let dnsdisc_cfg = DnsDiscoveryConfig::default();
+        let peer_config = PeersConfig::default()
+            .with_max_outbound(0)
+            .with_max_inbound(10000);
 
+        // disable discovery here since we already handle outbound connections (devp2p/eth handshakes in our case) for newly discovered peers "manually", and do not need Swarm/NetworkState to handle those outbound handshakes for us
+        // we do however want inbound TCP (note: discv4 listens only for udp disc proto messages) connections to be handled
+        let builder = NetworkConfig::<()>::builder(key)
+            .disable_discovery()
+            .peer_config(peer_config);
+
+        let net_conf = builder.build(Arc::from(NoopProvider::default()));
+        let network = NetworkManager::new(net_conf).await.unwrap();
+        let net_handle = network.handle().clone();
+
+        let dnsdisc_cfg = DnsDiscoveryConfig::default();
         // Start discovery protocol
         let discv4 = Discv4::spawn(enr.udp_addr(), enr, key, discv4_cfg.build())
             .await
@@ -41,15 +58,23 @@ impl CrawlerFactory {
             dnsdisc_cfg,
         );
         dns_disc_service.spawn();
+        tokio::spawn(network);
 
         Self {
             key,
             discv4,
             dnsdisc,
+            network: net_handle,
         }
     }
 
     pub async fn make(&self) -> CrawlerService {
-        CrawlerService::new(self.discv4.clone(), self.dnsdisc.clone(), self.key).await
+        CrawlerService::new(
+            self.discv4.clone(),
+            self.dnsdisc.clone(),
+            self.network.clone(),
+            self.key,
+        )
+        .await
     }
 }

--- a/bins/reth-crawler/src/crawler/service.rs
+++ b/bins/reth-crawler/src/crawler/service.rs
@@ -1,6 +1,7 @@
 use futures::join;
 use reth_discv4::Discv4;
 use reth_dns_discovery::DnsDiscoveryHandle;
+use reth_network::NetworkHandle;
 use reth_primitives::NodeRecord;
 use secp256k1::SecretKey;
 use tokio::sync::mpsc;
@@ -12,16 +13,22 @@ pub struct CrawlerService {
 }
 
 impl CrawlerService {
-    pub async fn new(discv4: Discv4, dnsdisc: DnsDiscoveryHandle, key: SecretKey) -> Self {
+    pub async fn new(
+        discv4: Discv4,
+        dnsdisc: DnsDiscoveryHandle,
+        network: NetworkHandle,
+        key: SecretKey,
+    ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<Vec<NodeRecord>>();
-        let updates = UpdateListener::new(discv4.clone(), dnsdisc.clone(), key, tx.clone()).await;
+        let updates = UpdateListener::new(discv4, dnsdisc, network, key, tx).await;
         Self { updates }
     }
 
-    pub async fn run(self, save_to_json: bool) -> (eyre::Result<()>, eyre::Result<()>) {
+    pub async fn run(self, save_to_json: bool) -> (eyre::Result<()>, eyre::Result<()>, ()) {
         join!(
             self.updates.start_discv4(save_to_json),
             self.updates.start_dnsdisc(save_to_json),
+            self.updates.start_network(save_to_json),
         )
     }
 }

--- a/bins/reth-crawler/src/main.rs
+++ b/bins/reth-crawler/src/main.rs
@@ -37,7 +37,7 @@ async fn main() {
 
     match &cli.command {
         Commands::Crawl(opts) => {
-            let (_, _) = CrawlerFactory::new()
+            let (_, _, _) = CrawlerFactory::new()
                 .await
                 .make()
                 .await


### PR DESCRIPTION
![Screenshot 2023-10-29 at 9 48 48 AM](https://github.com/Keep-Reth-Strange/reth-crawler/assets/134806363/dc3c1a01-a32f-4cc1-8a63-79c49668fb5f)

![Screenshot 2023-10-29 at 9 58 12 AM](https://github.com/Keep-Reth-Strange/reth-crawler/assets/134806363/aadec907-c721-43f3-be30-bd48474f2b38)

currently running this across 17 nodes across aws regions

still room for improvement to retry `Too Many Peer` disconnect events strategically

> Our scanner should accept all incoming connections
and never send out Too many peers disconnects. Our scanner
will also attempt to overcome the Too many peers messages it
receives by slowly and deliberately re-attempting to connect to
nodes at max peer capacit

https://joshm.web.engr.illinois.edu/imc18_ethereum.pdf
