### PR TITLE
feat: add database synchronization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4324,6 +4324,7 @@ dependencies = [
  "aws-config",
  "aws-sdk-dynamodb",
  "axum",
+ "chrono",
  "clap",
  "reth-crawler-db",
  "serde",

--- a/bins/api-server/Cargo.toml
+++ b/bins/api-server/Cargo.toml
@@ -10,6 +10,7 @@ aws-sdk-dynamodb.workspace = true
 
 # general
 clap.workspace = true
+chrono.workspace = true
 axum = { version = "0.6.4", features = ["macros"] }
 tokio.workspace = true
 tokio-stream.workspace = true

--- a/bins/api-server/src/db_sync.rs
+++ b/bins/api-server/src/db_sync.rs
@@ -1,0 +1,41 @@
+use chrono::{Duration, Utc};
+use reth_crawler_db::{AwsPeerDB, PeerDB, SqlPeerDB};
+use std::error::Error;
+
+const PAGE_SIZE: Option<i32> = None;
+
+async fn db_sync(update_time: i64) -> Result<(), Box<dyn Error>> {
+    // dynamoDB setup
+    let dynamo_db = AwsPeerDB::new().await;
+    // sqliteDB setup
+    let sqlite_db = SqlPeerDB::new().await;
+
+    // take the time difference from last update (every 5 minutes)
+    let now = Utc::now();
+    let time_difference = now
+        // + 1 is to be sure to collect all update peers. So we collect all peers that have been added or edited in the last 6 minutes.
+        .checked_sub_signed(Duration::minutes(update_time + 1))
+        .unwrap()
+        .to_string();
+
+    // scan table
+    let peers = dynamo_db.all_last_peers(time_difference, PAGE_SIZE).await?;
+
+    // update sqliteDB from dynamoDB
+    for peer in peers {
+        sqlite_db.add_peer(peer).await?;
+    }
+
+    Ok(())
+}
+
+pub async fn db_sync_handler(update_time: i64) -> Result<(), Box<dyn Error>> {
+    // we can unwrap because `update_time` is fixed to +5 minutes.
+    let mut interval = tokio::time::interval(Duration::seconds(update_time).to_std().unwrap());
+    loop {
+        interval.tick().await;
+        let now = Utc::now();
+        let update_time = (now.timestamp() - update_time) / 60; // Convert to minutes
+        db_sync(update_time).await?
+    }
+}

--- a/bins/reth-crawler/src/crawler/factory.rs
+++ b/bins/reth-crawler/src/crawler/factory.rs
@@ -68,13 +68,12 @@ impl CrawlerFactory {
         }
     }
 
-    pub async fn make(&self, sql_db: bool) -> CrawlerService {
+    pub async fn make(&self) -> CrawlerService {
         CrawlerService::new(
             self.discv4.clone(),
             self.dnsdisc.clone(),
             self.network.clone(),
             self.key,
-            sql_db,
         )
         .await
     }

--- a/bins/reth-crawler/src/crawler/listener/update_listener.rs
+++ b/bins/reth-crawler/src/crawler/listener/update_listener.rs
@@ -32,27 +32,16 @@ impl UpdateListener {
         network: NetworkHandle,
         key: SecretKey,
         node_tx: UnboundedSender<Vec<NodeRecord>>,
-        sql_db: bool,
     ) -> Self {
         let p2p_failures = Arc::from(RwLock::from(HashMap::new()));
-        if sql_db {
-            UpdateListener {
-                discv4,
-                dnsdisc,
-                key,
-                db: Arc::new(SqlPeerDB::new().await),
-                network,
-                p2p_failures,
-            }
-        } else {
-            UpdateListener {
-                discv4,
-                dnsdisc,
-                key,
-                db: Arc::new(AwsPeerDB::new().await),
-                network,
-                p2p_failures,
-            }
+
+        UpdateListener {
+            discv4,
+            dnsdisc,
+            key,
+            db: Arc::new(AwsPeerDB::new().await),
+            network,
+            p2p_failures,
         }
     }
 

--- a/bins/reth-crawler/src/crawler/service.rs
+++ b/bins/reth-crawler/src/crawler/service.rs
@@ -18,10 +18,9 @@ impl CrawlerService {
         dnsdisc: DnsDiscoveryHandle,
         network: NetworkHandle,
         key: SecretKey,
-        sql_db: bool,
     ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<Vec<NodeRecord>>();
-        let updates = UpdateListener::new(discv4, dnsdisc, network, key, tx, sql_db).await;
+        let updates = UpdateListener::new(discv4, dnsdisc, network, key, tx).await;
         Self { updates }
     }
 

--- a/bins/reth-crawler/src/main.rs
+++ b/bins/reth-crawler/src/main.rs
@@ -24,9 +24,6 @@ enum Commands {
 
 #[derive(Args)]
 struct CrawlOpts {
-    #[arg(long, conflicts_with = "save_to_json")]
-    /// Save peers into an in memory db. This is useful for local testing because you don't have to setup a centralized database.
-    sql_db: bool,
     #[arg(long, conflicts_with = "sql_db")]
     /// Save file into a json file called `peers_node.json` instead of saving them into a database.
     save_to_json: bool,
@@ -42,7 +39,7 @@ async fn main() {
         Commands::Crawl(opts) => {
             let (_, _, _) = CrawlerFactory::new()
                 .await
-                .make(opts.sql_db)
+                .make()
                 .await
                 .run(opts.save_to_json)
                 .await;


### PR DESCRIPTION
This PR adds the following:

- always use `dynamoDB` for the crawler.
- always use `SQLiteDB` for the api server.
- the api server periodically (every 5 minutes) performs an update of its sqlite database, fetching data from dynamoDB.

Right now my solution for the periodically updates only updates newly added or edited peers (using `last_seen`) in the last 6 minutes (it's 5 minutes + 1 for security).

It actually performs a full scan of the `dynamoDB` database but then only add or update the new ones in the `SQLiteDB`. Maybe we can do even better, like querying and not scanning the table, but this requires to add a new secondary index in the `dynamoDB`.