### PR TITLE
(fix) remove save_to_json flag, crawler bin panicking

### DIFF
--- a/bins/reth-crawler/src/crawler/listener/update_listener.rs
+++ b/bins/reth-crawler/src/crawler/listener/update_listener.rs
@@ -45,7 +45,7 @@ impl UpdateListener {
         }
     }
 
-    pub async fn start_discv4(&self, save_to_json: bool) -> eyre::Result<()> {
+    pub async fn start_discv4(&self) -> eyre::Result<()> {
         let mut discv4_stream = self.discv4.update_stream().await?;
         let key = self.key;
         while let Some(update) = discv4_stream.next().await {
@@ -169,14 +169,14 @@ impl UpdateListener {
                         country,
                         city,
                     };
-                    save_peer(peer_data, save_to_json, db).await;
+                    save_peer(peer_data, db).await;
                 });
             }
         }
         Ok(())
     }
 
-    pub async fn start_dnsdisc(&self, save_to_json: bool) -> eyre::Result<()> {
+    pub async fn start_dnsdisc(&self) -> eyre::Result<()> {
         let mut dnsdisc_update_stream = self.dnsdisc.node_record_stream().await?;
         let key = self.key;
         while let Some(update) = dnsdisc_update_stream.next().await {
@@ -299,13 +299,13 @@ impl UpdateListener {
                     country,
                     city,
                 };
-                save_peer(peer_data, save_to_json, db).await;
+                save_peer(peer_data, db).await;
             });
         }
         Ok(())
     }
 
-    pub async fn start_network(&self, save_to_json: bool) {
+    pub async fn start_network(&self) {
         let mut net_events = self.network.event_listener();
 
         while let Some(event) = net_events.next().await {
@@ -378,7 +378,7 @@ impl UpdateListener {
                             country,
                             city,
                         };
-                        save_peer(peer_data, save_to_json, db).await;
+                        save_peer(peer_data, db).await;
                     });
                 }
                 NetworkEvent::PeerAdded(_) | NetworkEvent::PeerRemoved(_) => {}

--- a/bins/reth-crawler/src/crawler/service.rs
+++ b/bins/reth-crawler/src/crawler/service.rs
@@ -24,11 +24,11 @@ impl CrawlerService {
         Self { updates }
     }
 
-    pub async fn run(self, save_to_json: bool) -> (eyre::Result<()>, eyre::Result<()>, ()) {
+    pub async fn run(self) -> (eyre::Result<()>, eyre::Result<()>, ()) {
         join!(
-            self.updates.start_discv4(save_to_json),
-            self.updates.start_dnsdisc(save_to_json),
-            self.updates.start_network(save_to_json),
+            self.updates.start_discv4(),
+            self.updates.start_dnsdisc(),
+            self.updates.start_network(),
         )
     }
 }

--- a/bins/reth-crawler/src/main.rs
+++ b/bins/reth-crawler/src/main.rs
@@ -23,11 +23,7 @@ enum Commands {
 }
 
 #[derive(Args)]
-struct CrawlOpts {
-    #[arg(long, conflicts_with = "sql_db")]
-    /// Save file into a json file called `peers_node.json` instead of saving them into a database.
-    save_to_json: bool,
-}
+struct CrawlOpts {}
 
 #[tokio::main]
 async fn main() {
@@ -36,13 +32,8 @@ async fn main() {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Crawl(opts) => {
-            let (_, _, _) = CrawlerFactory::new()
-                .await
-                .make()
-                .await
-                .run(opts.save_to_json)
-                .await;
+        Commands::Crawl(_) => {
+            let (_, _, _) = CrawlerFactory::new().await.make().await.run().await;
         }
     }
 }

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -23,13 +23,6 @@ pub async fn append_to_file(peer_data: PeerData) -> eyre::Result<()> {
 }
 
 /// Helper function to save a peer.
-pub async fn save_peer(peer_data: PeerData, save_to_json: bool, db: Arc<dyn PeerDB>) {
-    if save_to_json {
-        match append_to_file(peer_data).await {
-            Ok(_) => (),
-            Err(e) => error!("Error appending to file: {:?}", e),
-        }
-    } else {
-        db.add_peer(peer_data).await.unwrap();
-    }
+pub async fn save_peer(peer_data: PeerData, db: Arc<dyn PeerDB>) {
+    db.add_peer(peer_data).await.unwrap();
 }


### PR DESCRIPTION
fixes 
```
thread 'main' panicked at 'Command crawl: Argument or group 'sql_db' specified in 'conflicts_with*' for 'save_to_json' does not exist', /Users/prithvi/.cargo/registry/src/index.crates.io-6f17d22bba15001f/clap_builder-4.4.7/src/builder/debug_asserts.rs:214:13
```

introduced in #29 