### PR TITLE
feat: add a `--local-db` flag for local testing the crawler

### DIFF
--- a/bins/reth-crawler/src/crawler/factory.rs
+++ b/bins/reth-crawler/src/crawler/factory.rs
@@ -68,12 +68,13 @@ impl CrawlerFactory {
         }
     }
 
-    pub async fn make(&self) -> CrawlerService {
+    pub async fn make(&self, local_db: bool) -> CrawlerService {
         CrawlerService::new(
             self.discv4.clone(),
             self.dnsdisc.clone(),
             self.network.clone(),
             self.key,
+            local_db,
         )
         .await
     }

--- a/bins/reth-crawler/src/crawler/listener/update_listener.rs
+++ b/bins/reth-crawler/src/crawler/listener/update_listener.rs
@@ -32,16 +32,28 @@ impl UpdateListener {
         network: NetworkHandle,
         key: SecretKey,
         node_tx: UnboundedSender<Vec<NodeRecord>>,
+        local_db: bool,
     ) -> Self {
         let p2p_failures = Arc::from(RwLock::from(HashMap::new()));
 
-        UpdateListener {
-            discv4,
-            dnsdisc,
-            key,
-            db: Arc::new(AwsPeerDB::new().await),
-            network,
-            p2p_failures,
+        if local_db {
+            UpdateListener {
+                discv4,
+                dnsdisc,
+                key,
+                db: Arc::new(SqlPeerDB::new().await),
+                network,
+                p2p_failures,
+            }
+        } else {
+            UpdateListener {
+                discv4,
+                dnsdisc,
+                key,
+                db: Arc::new(AwsPeerDB::new().await),
+                network,
+                p2p_failures,
+            }
         }
     }
 

--- a/bins/reth-crawler/src/crawler/service.rs
+++ b/bins/reth-crawler/src/crawler/service.rs
@@ -18,9 +18,10 @@ impl CrawlerService {
         dnsdisc: DnsDiscoveryHandle,
         network: NetworkHandle,
         key: SecretKey,
+        local_db: bool,
     ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<Vec<NodeRecord>>();
-        let updates = UpdateListener::new(discv4, dnsdisc, network, key, tx).await;
+        let updates = UpdateListener::new(discv4, dnsdisc, network, key, tx, local_db).await;
         Self { updates }
     }
 

--- a/bins/reth-crawler/src/main.rs
+++ b/bins/reth-crawler/src/main.rs
@@ -23,7 +23,11 @@ enum Commands {
 }
 
 #[derive(Args)]
-struct CrawlOpts {}
+struct CrawlOpts {
+    #[arg(long)]
+    /// Use a sqlite db for local testing.
+    local_db: bool,
+}
 
 #[tokio::main]
 async fn main() {
@@ -32,8 +36,13 @@ async fn main() {
     let cli = Cli::parse();
 
     match &cli.command {
-        Commands::Crawl(_) => {
-            let (_, _, _) = CrawlerFactory::new().await.make().await.run().await;
+        Commands::Crawl(opts) => {
+            let (_, _, _) = CrawlerFactory::new()
+                .await
+                .make(opts.local_db)
+                .await
+                .run()
+                .await;
         }
     }
 }


### PR DESCRIPTION
This PR adds a `--local-db` flag on the crawler for local testing.

It runs the crawler using a sqlite db instead of the dynamodb one.

NOTE: you cannot use the api server if you are local testing your crawler since right now api server takes data from dynamo db only.

RUN:

```bash
cargo run --bin reth-crawler crawl --local-db
```

<img width="1035" alt="Screenshot 2023-11-01 at 15 25 20" src="https://github.com/Keep-Reth-Strange/reth-crawler/assets/121622391/e0fe127d-ded9-4a00-b04c-ac54db9d0083">