### PR TITLE
feat: prune peers older than one day in the sqlite db

### DIFF
--- a/bins/api-server/src/db_sync.rs
+++ b/bins/api-server/src/db_sync.rs
@@ -3,6 +3,9 @@ use reth_crawler_db::{AwsPeerDB, PeerDB, SqlPeerDB};
 use std::error::Error;
 
 const PAGE_SIZE: Option<i32> = None;
+/// This is the time validity for peers inside the sqlite db. It's one day in seconds.
+/// After one day a peer is considered invalid and it's deleted from the sqlite db.
+const PEERS_VALIDITY: i64 = 60 * 60 * 24;
 
 async fn db_sync(update_time: i64, first_sync: bool) -> Result<(), Box<dyn Error>> {
     // dynamoDB setup
@@ -30,6 +33,9 @@ async fn db_sync(update_time: i64, first_sync: bool) -> Result<(), Box<dyn Error
         sqlite_db.add_peer(peer, None).await?;
     }
 
+    // prune data older than a day in the sqliteDB
+    sqlite_db.prune_peers(PEERS_VALIDITY).await?;
+
     Ok(())
 }
 
@@ -39,7 +45,6 @@ pub async fn db_sync_handler(update_time: i64) -> Result<(), Box<dyn Error>> {
     let mut first_sync = true;
     loop {
         interval.tick().await;
-        let now = Utc::now();
         db_sync(update_time, first_sync).await?;
         first_sync = false;
     }

--- a/bins/api-server/src/db_sync.rs
+++ b/bins/api-server/src/db_sync.rs
@@ -3,9 +3,9 @@ use reth_crawler_db::{AwsPeerDB, PeerDB, SqlPeerDB};
 use std::error::Error;
 
 const PAGE_SIZE: Option<i32> = None;
-/// This is the time validity for peers inside the sqlite db. It's one day in seconds.
+/// This is the time validity for peers inside the sqlite db. It's in days.
 /// After one day a peer is considered invalid and it's deleted from the sqlite db.
-const PEERS_VALIDITY: i64 = 60 * 60 * 24;
+const PEERS_VALIDITY: i64 = 1;
 
 async fn db_sync(update_time: i64, first_sync: bool) -> Result<(), Box<dyn Error>> {
     // dynamoDB setup

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -409,10 +409,10 @@ impl PeerDB for SqlPeerDB {
 }
 
 impl SqlPeerDB {
-    /// Prune peers that are older than `time_validity`. Note that `time_validity` **MUST** be in seconds.
+    /// Prune peers that are older than `time_validity`. Note that `time_validity` **MUST** be in days.
     pub async fn prune_peers(&self, time_validity: i64) -> Result<(), DeleteItemError> {
         let cutoff = Utc::now()
-            .checked_sub_signed(Duration::seconds(time_validity))
+            .checked_sub_signed(Duration::days(time_validity))
             .unwrap()
             .to_string();
         self.db

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -424,6 +424,7 @@ impl SqlPeerDB {
             })
             .await
             .map_err(|err| DeleteItemError::SqlDeleteItemError(err))?;
+
         Ok(())
     }
 }

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -1,4 +1,4 @@
-use crate::types::{AddItemError, PeerData, QueryItemError, ScanTableError};
+use crate::types::{AddItemError, DeleteItemError, PeerData, QueryItemError, ScanTableError};
 use async_trait::async_trait;
 use aws_config::meta::region::RegionProviderChain;
 use aws_sdk_dynamodb::types::AttributeValue;
@@ -405,5 +405,25 @@ impl PeerDB for SqlPeerDB {
             .map_err(|err| QueryItemError::SqlQueryItemError(err))?;
 
         Ok(Some(peers))
+    }
+}
+
+impl SqlPeerDB {
+    /// Prune peers that are older than `time_validity`. Note that `time_validity` **MUST** be in seconds.
+    pub async fn prune_peers(&self, time_validity: i64) -> Result<(), DeleteItemError> {
+        let cutoff = Utc::now()
+            .checked_sub_signed(Duration::seconds(time_validity))
+            .unwrap()
+            .to_string();
+        self.db
+            .call(move |conn| {
+                conn.execute(
+                    "DELETE FROM eth_peer_data WHERE last_seen < ?1 ",
+                    [cutoff.as_str()],
+                )
+            })
+            .await
+            .map_err(|err| DeleteItemError::SqlDeleteItemError(err))?;
+        Ok(())
     }
 }

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -8,7 +8,7 @@ use aws_sdk_dynamodb::{
     types::AttributeValue,
 };
 
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct PeerData {
     pub enode_url: String,
     pub id: String,

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -157,3 +157,9 @@ pub enum QueryItemError {
     #[error("An error occurred querying the SQL database: {0}")]
     SqlQueryItemError(#[from] tokio_rusqlite::Error),
 }
+
+#[derive(Debug, Error)]
+pub enum DeleteItemError {
+    #[error("An error occurred deleting a new item into the SQL database: {0}")]
+    SqlDeleteItemError(#[from] tokio_rusqlite::Error),
+}


### PR DESCRIPTION
Now also the sqlite db for the api server prunes data that are older than one day, using `last_seen` field of the peers.