### PR TITLE
(fix) tracing in apiserver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4331,6 +4331,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/bins/api-server/Cargo.toml
+++ b/bins/api-server/Cargo.toml
@@ -15,6 +15,7 @@ axum = { version = "0.6.4", features = ["macros"] }
 tokio.workspace = true
 tokio-stream.workspace = true
 tracing.workspace = true
+tracing-subscriber.workspace = true
 
 # serialization
 serde.workspace = true

--- a/bins/api-server/src/db_sync.rs
+++ b/bins/api-server/src/db_sync.rs
@@ -1,6 +1,7 @@
 use chrono::{Duration, Utc};
 use reth_crawler_db::{AwsPeerDB, PeerDB, SqlPeerDB};
 use std::error::Error;
+use tracing::info;
 
 const PAGE_SIZE: Option<i32> = None;
 /// This is the time validity for peers inside the sqlite db. It's in days.

--- a/bins/api-server/src/main.rs
+++ b/bins/api-server/src/main.rs
@@ -36,6 +36,7 @@ enum Commands {
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+    tracing_subscriber::fmt::init();
     let start_api_server_futures = {
         match cli.command {
             Commands::StartApiServer => start_api_server(),

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -6,7 +6,6 @@ use tokio::{fs::OpenOptions, io::AsyncWriteExt};
 
 // Re-exports
 pub use db::{AwsPeerDB, InMemoryPeerDB, PeerDB, SqlPeerDB};
-use tracing::error;
 pub use types::PeerData;
 
 /// Helper function to append a peer to file


### PR DESCRIPTION
tested locally:
```
2023-11-01T17:08:14.401980Z  INFO lazy_load_credentials: aws_credential_types::cache::lazy_caching: credentials cache miss occurred; added new AWS credentials (took Ok(128µs))
2023-11-01T17:08:23.305529Z  INFO reth_crawler_db::db: Number of peers pruned: 0
```