### PR TITLE
(feat) add /clients endpoint for client diversity dashboard

### DIFF
--- a/bins/api-server/src/peerdb/routes.rs
+++ b/bins/api-server/src/peerdb/routes.rs
@@ -5,7 +5,7 @@ use axum::{
     routing::get,
     Json, Router,
 };
-use reth_crawler_db::{PeerDB, PeerData};
+use reth_crawler_db::{types::ClientData, PeerDB, PeerData};
 
 use super::app_state::AppState;
 
@@ -14,10 +14,26 @@ pub fn rest_router() -> Router<AppState> {
         .route("/nodes", get(get_nodes))
         .route("/node/id/:id", get(get_node_by_id))
         .route("/node/ip/:ip", get(get_node_by_ip))
+        .route("/clients", get(get_clients))
 }
 
 async fn get_nodes(State(store): State<Arc<dyn PeerDB>>) -> Json<Vec<PeerData>> {
     Json(store.all_peers(Some(50)).await.unwrap())
+}
+
+async fn get_clients(State(store): State<Arc<dyn PeerDB>>) -> Json<Vec<ClientData>> {
+    Json(
+        store
+            .all_peers(Some(50))
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|peer| {
+                let client_version = peer.client_version;
+                ClientData { client_version }
+            })
+            .collect(),
+    )
 }
 
 async fn get_node_by_id(

--- a/db/src/types.rs
+++ b/db/src/types.rs
@@ -163,3 +163,8 @@ pub enum DeleteItemError {
     #[error("An error occurred deleting a new item into the SQL database: {0}")]
     SqlDeleteItemError(#[from] tokio_rusqlite::Error),
 }
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct ClientData {
+    pub client_version: String,
+}


### PR DESCRIPTION
tested locally - `/nodes` takes 5s (outlier of 30s sometimes) to load data with all attributes in the browser:
![Screenshot 2023-11-01 at 9 48 08 PM](https://github.com/Keep-Reth-Strange/reth-crawler/assets/134806363/fe79181e-2da6-45f4-9312-ae59a8aa8f7b)
![Screenshot 2023-11-01 at 9 48 33 PM](https://github.com/Keep-Reth-Strange/reth-crawler/assets/134806363/f9499409-7fc9-45dd-9fa0-10e5dbb59e68)


`/clients` takes ~100 ms to load all the relevant client data - we want to do this instead to populate the dashboard:

![Screenshot 2023-11-01 at 9 46 06 PM](https://github.com/Keep-Reth-Strange/reth-crawler/assets/134806363/08e3926e-e10a-45b3-a39b-78c7d88e274d)
