### PR TITLE
(chore) track nodes on a rolling 72 hours basis

### DIFF
--- a/bins/api-server/src/db_sync.rs
+++ b/bins/api-server/src/db_sync.rs
@@ -5,8 +5,8 @@ use tracing::info;
 
 const PAGE_SIZE: Option<i32> = None;
 /// This is the time validity for peers inside the sqlite db. It's in days.
-/// After one day a peer is considered invalid and it's deleted from the sqlite db.
-const PEERS_VALIDITY: i64 = 1;
+/// After 3 days a peer is considered invalid and it's deleted from the sqlite db.
+const PEERS_VALIDITY: i64 = 3;
 
 async fn db_sync(update_time: i64, first_sync: bool) -> Result<(), Box<dyn Error>> {
     // dynamoDB setup

--- a/bins/reth-crawler/src/crawler/listener/update_listener.rs
+++ b/bins/reth-crawler/src/crawler/listener/update_listener.rs
@@ -130,7 +130,7 @@ impl UpdateListener {
                     }
 
                     let ttl = Utc::now()
-                        .checked_add_days(Days::new(1))
+                        .checked_add_days(Days::new(3))
                         .unwrap()
                         .timestamp();
                     let last_seen = Utc::now().to_string();
@@ -265,7 +265,7 @@ impl UpdateListener {
                     return;
                 }
                 let ttl = Utc::now()
-                    .checked_add_days(Days::new(1))
+                    .checked_add_days(Days::new(3))
                     .unwrap()
                     .timestamp();
                 let last_seen = Utc::now().to_string();
@@ -362,7 +362,7 @@ impl UpdateListener {
                         let best_block = status.blockhash.to_string();
                         let genesis_block_hash = status.genesis.to_string();
                         let ttl = Utc::now()
-                            .checked_add_days(Days::new(1))
+                            .checked_add_days(Days::new(3))
                             .unwrap()
                             .timestamp();
                         let last_seen = Utc::now().to_string();

--- a/db/src/db.rs
+++ b/db/src/db.rs
@@ -117,7 +117,7 @@ impl PeerDB for AwsPeerDB {
     async fn all_peers(&self, page_size: Option<i32>) -> Result<Vec<PeerData>, ScanTableError> {
         let page_size = page_size.unwrap_or(1000);
         let cutoff = Utc::now()
-            .checked_sub_signed(Duration::hours(24))
+            .checked_sub_signed(Duration::hours(72))
             .unwrap()
             .to_string();
         let results: Result<Vec<_>, _> = self


### PR DESCRIPTION
we are currently tracking 12.4k unique peers on a rolling 24 hours basis

this has been in steady state for the past ~4 hours


bump the db ttl to 72 hours instead to track peers over 3 days

we can eventually add an additional filter to the dashboarding/data collection if users want peers only from the past day 