### PR TITLE
fix dockerfile for crawler, add api-server

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,12 +3,13 @@ FROM  rustlang/rust:nightly AS builder
 RUN apt-get update -y && \
     apt-get satisfy --no-install-recommends -y "\
         libclang-dev, \
-        ca-certificates (>= 20210119), \
-        curl (>= 7.74), curl (<< 7.75), \
-        lld (>= 1:11.0), lld (<< 1:11.1), \
-        pkg-config (>= 0.29), pkg-config (<< 0.30), \
-        libssl-dev (>= 1.1), libssl-dev (<< 1.2), \
-        git (>= 1:2.30), git (<< 1:2.31) \
+        ca-certificates, \
+        curl, \
+        lld, \
+        pkg-config, \
+        libssl-dev, \
+        git, \
+        libsqlite3-dev \
     "
 
 WORKDIR /workdir                       
@@ -18,18 +19,29 @@ COPY ./bins ./bins
 COPY ./db ./db
 RUN cargo +nightly build --release
 
-FROM debian:bullseye-20230202-slim
-RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install --yes \
-    libcurl4 \
-    && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+FROM debian:bullseye-20230202-slim as reth-crawler
+RUN apt-get update && apt-get install -y sqlite3 libcurl4 && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 COPY --from=0 /workdir/target/release/reth-crawler /usr/bin/reth-crawler
 COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-RUN ls /usr/bin
 RUN chmod +x /usr/bin/reth-crawler
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 ENV SSL_CERT_DIR=/etc/ssl/certs
 ENV RUST_LOG=info
 EXPOSE 30303
 EXPOSE 30303/udp
-ENTRYPOINT ["/usr/bin/reth-crawler", "crawl"]
+CMD ["/usr/bin/reth-crawler", "crawl"]
+LABEL service=reth-crawler
+
+FROM debian:bullseye-20230202-slim as reth-api-server
+RUN apt-get update && apt-get install -y sqlite3 libcurl4 && apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+COPY --from=0 /workdir/target/release/reth-crawler-api-server /usr/bin/reth-api-server
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+RUN chmod +x /usr/bin/reth-api-server
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_DIR=/etc/ssl/certs
+ENV RUST_LOG=info
+EXPOSE 3030
+CMD ["/usr/bin/reth-api-server", "start-api-server"]
+LABEL service=reth-api-server


### PR DESCRIPTION
```
docker run reth-crawler:test
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
2023-11-03T14:42:58.053791Z  WARN load_region{provider=DefaultRegionChain(RegionProviderChain { providers: [EnvironmentVariableRegionProvider { env: Env(Real) }, ProfileFileRegionProvider { provider_config: ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(SharedAsyncSleep(TokioSleep)), region: None } }, ImdsRegionProvider { client: LazyClient { client: OnceCell { value: None }, builder: Builder { max_attempts: None, endpoint: None, mode_override: None, token_ttl: None, connect_timeout: None, read_timeout: None, config: Some(ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(SharedAsyncSleep(TokioSleep)), region: None }) } }, env: Env(Real) }] })}:load_region{provider=ImdsRegionProvider { client: LazyClient { client: OnceCell { value: None }, builder: Builder { max_attempts: None, endpoint: None, mode_override: None, token_ttl: None, connect_timeout: None, read_timeout: None, config: Some(ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(SharedAsyncSleep(TokioSleep)), region: None }) } }, env: Env(Real) }}: aws_config::imds::region: failed to load region from IMDS err=failed to load IMDS session token: dispatch failure: timeout: error trying to connect: HTTP connect timeout occurred after 1s: HTTP connect timeout occurred after 1s: timed out (FailedToLoadToken(FailedToLoadToken { source: DispatchFailure(DispatchFailure { source: ConnectorError { kind: Timeout, source: hyper::Error(Connect, HttpTimeoutError { kind: "HTTP connect", duration: 1s }), connection: Unknown } }) }))

                                                                                                                                                                                                                                     
docker run reth-api-server:test
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
2023-11-03T14:43:14.838101Z  WARN load_region{provider=DefaultRegionChain(RegionProviderChain { providers: [EnvironmentVariableRegionProvider { env: Env(Real) }, ProfileFileRegionProvider { provider_config: ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(SharedAsyncSleep(TokioSleep)), region: None } }, ImdsRegionProvider { client: LazyClient { client: OnceCell { value: None }, builder: Builder { max_attempts: None, endpoint: None, mode_override: None, token_ttl: None, connect_timeout: None, read_timeout: None, config: Some(ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(SharedAsyncSleep(TokioSleep)), region: None }) } }, env: Env(Real) }] })}:load_region{provider=ImdsRegionProvider { client: LazyClient { client: OnceCell { value: None }, builder: Builder { max_attempts: None, endpoint: None, mode_override: None, token_ttl: None, connect_timeout: None, read_timeout: None, config: Some(ProviderConfig { env: Env(Real), fs: Fs(Real), sleep: Some(SharedAsyncSleep(TokioSleep)), region: None }) } }, env: Env(Real) }}: aws_config::imds::region: failed to load region from IMDS err=failed to load IMDS session token: dispatch failure: io error: error trying to connect: tcp connect error: Connection refused (os error 111): tcp connect error: Connection refused (os error 111): Connection refused (os error 111) (FailedToLoadToken(FailedToLoadToken { source: DispatchFailure(DispatchFailure { source: ConnectorError { kind: Io, source: hyper::Error(Connect, ConnectError("tcp connect error", Os { code: 111, kind: ConnectionRefused, message: "Connection refused" })), connection: Unknown } }) }))
2023-11-03T14:43:14.909382Z  INFO reth_crawler_api_server: Server started, listening on 127.0.0.1:3030
Error: AwsScanError(DispatchFailure(DispatchFailure { source: ConnectorError { kind: Other(None), source: CredentialsNotLoaded(CredentialsNotLoaded { source: "no providers in chain provided credentials" }), connection: Unknown } }))
```

tested locally (thus the IMDS errors for creds) and deployed api-server docker on ecs