### PR TITLE
docker: add cacheing for cargo deps

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+*
+
+!/bins
+!/db
+!Cargo.lock
+!Cargo.toml


### PR DESCRIPTION
 testing locally - but fixing apiserver concurrent lag includes abysmal build times for the container

speed up builds to make dev loop faster
