### PR TITLE
fix: cargo-chef bullseye-slim base to match runner distro

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1 AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-slim-bullseye AS chef
 WORKDIR workdir
 
 From chef as planner


### PR DESCRIPTION
before:
```
 version `GLIBC_2.32' not found
```

now:
```
docker run reth-api-server:test
2023-11-04T14:13:07.503747Z  INFO reth_crawler_api_server: Server started, listening on 0.0.0.0:3030
```
