### PR TITLE
feat: use cli arg for eth rpc url and use builder pattern

### DIFF
--- a/bins/reth-crawler/src/crawler/factory.rs
+++ b/bins/reth-crawler/src/crawler/factory.rs
@@ -1,14 +1,11 @@
 use once_cell::sync::Lazy;
 use reth_discv4::{Discv4, Discv4ConfigBuilder, DEFAULT_DISCOVERY_ADDRESS};
-use reth_dns_discovery::{
-    DnsDiscoveryConfig, DnsDiscoveryHandle, DnsDiscoveryService, DnsResolver,
-};
+use reth_dns_discovery::{DnsDiscoveryConfig, DnsDiscoveryService, DnsResolver};
 
 use reth_network::config::rng_secret_key;
-use reth_network::{NetworkConfig, NetworkHandle, NetworkManager, PeersConfig};
+use reth_network::{NetworkConfig, NetworkManager, PeersConfig};
 use reth_primitives::{mainnet_nodes, NodeRecord};
 use reth_provider::test_utils::NoopProvider;
-use secp256k1::SecretKey;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -16,15 +13,57 @@ use crate::crawler::CrawlerService;
 
 pub static MAINNET_BOOT_NODES: Lazy<Vec<NodeRecord>> = Lazy::new(mainnet_nodes);
 
-pub struct CrawlerFactory {
-    key: SecretKey,
-    discv4: Discv4,
-    dnsdisc: DnsDiscoveryHandle,
-    network: NetworkHandle,
+/// Builder for a [`CrawlerService`]
+#[derive(Clone, Debug)]
+pub struct CrawlerBuilder {
+    /// Whether or not to use a local db
+    local_db: bool,
+    /// Eth RPC url
+    eth_rpc_url: Option<String>,
+    /// Max inbound connections for the crawler
+    max_inbound: usize,
+    /// Max outbound connections for the crawler
+    max_outbound: usize,
+    /// The lookup interval for the crawler
+    lookup_interval: Duration,
 }
 
-impl CrawlerFactory {
-    pub async fn new() -> Self {
+impl Default for CrawlerBuilder {
+    fn default() -> Self {
+        Self {
+            local_db: false,
+            eth_rpc_url: None,
+            max_inbound: 10000,
+            max_outbound: 0,
+            lookup_interval: Duration::from_secs(3),
+        }
+    }
+}
+
+impl CrawlerBuilder {
+    /// Enable the local db
+    pub fn with_local_db(mut self) -> Self {
+        self.local_db = true;
+        self
+    }
+
+    /// Disable the local db
+    pub fn without_local_db(mut self) -> Self {
+        self.local_db = false;
+        self
+    }
+
+    /// Set the eth rpc url
+    pub fn with_eth_rpc_url(mut self, eth_rpc_url: String) -> Self {
+        self.eth_rpc_url = Some(eth_rpc_url);
+        self
+    }
+
+    /// Build the [`CrawlerService`]
+    pub async fn build(self) -> CrawlerService {
+        // Ensure the rpc url is set
+        let provider_url = self.eth_rpc_url.expect("eth rpc url must be provided");
+
         // Setup configs related to this 'node' by creating a new random
         let key = rng_secret_key();
         let enr = NodeRecord::from_secret_key(DEFAULT_DISCOVERY_ADDRESS, &key);
@@ -32,11 +71,11 @@ impl CrawlerFactory {
         let mut discv4_cfg = Discv4ConfigBuilder::default();
         discv4_cfg
             .add_boot_nodes(MAINNET_BOOT_NODES.clone())
-            .lookup_interval(Duration::from_secs(3));
+            .lookup_interval(self.lookup_interval);
 
         let peer_config = PeersConfig::default()
-            .with_max_outbound(0)
-            .with_max_inbound(10000);
+            .with_max_outbound(self.max_outbound)
+            .with_max_inbound(self.max_inbound);
 
         // disable discovery here since we already handle outbound connections (devp2p/eth handshakes in our case) for newly discovered peers "manually", and do not need Swarm/NetworkState to handle those outbound handshakes for us
         // we do however want inbound TCP (note: discv4 listens only for udp disc proto messages) connections to be handled
@@ -60,21 +99,13 @@ impl CrawlerFactory {
         dns_disc_service.spawn();
         tokio::spawn(network);
 
-        Self {
-            key,
+        CrawlerService::new(
             discv4,
             dnsdisc,
-            network: net_handle,
-        }
-    }
-
-    pub async fn make(&self, local_db: bool) -> CrawlerService {
-        CrawlerService::new(
-            self.discv4.clone(),
-            self.dnsdisc.clone(),
-            self.network.clone(),
-            self.key,
-            local_db,
+            net_handle,
+            key,
+            self.local_db,
+            provider_url,
         )
         .await
     }

--- a/bins/reth-crawler/src/crawler/listener/update_listener.rs
+++ b/bins/reth-crawler/src/crawler/listener/update_listener.rs
@@ -38,12 +38,11 @@ impl UpdateListener {
         key: SecretKey,
         node_tx: UnboundedSender<Vec<NodeRecord>>,
         local_db: bool,
+        provider_url: String,
     ) -> Self {
         let p2p_failures = Arc::from(RwLock::from(HashMap::new()));
         // initialize a new http provider
-        // this is a paradigm full node
-        let rpc_url = "http://69.67.151.138:8645";
-        let provider = Provider::try_from(rpc_url).expect("Provider must work correctly!");
+        let provider = Provider::try_from(provider_url).expect("Provider must work correctly!");
         if local_db {
             UpdateListener {
                 discv4,

--- a/bins/reth-crawler/src/crawler/mod.rs
+++ b/bins/reth-crawler/src/crawler/mod.rs
@@ -2,5 +2,5 @@ mod factory;
 mod listener;
 mod service;
 
-pub use self::factory::CrawlerFactory;
+pub use self::factory::CrawlerBuilder;
 pub use self::service::CrawlerService;

--- a/bins/reth-crawler/src/crawler/service.rs
+++ b/bins/reth-crawler/src/crawler/service.rs
@@ -19,9 +19,11 @@ impl CrawlerService {
         network: NetworkHandle,
         key: SecretKey,
         local_db: bool,
+        provider_url: String,
     ) -> Self {
         let (tx, rx) = mpsc::unbounded_channel::<Vec<NodeRecord>>();
-        let updates = UpdateListener::new(discv4, dnsdisc, network, key, tx, local_db).await;
+        let updates =
+            UpdateListener::new(discv4, dnsdisc, network, key, tx, local_db, provider_url).await;
         Self { updates }
     }
 


### PR DESCRIPTION
Just changed the factory to be based on a builder pattern, so the only `async` method is the build method. Also added an argument for eth RPC url and removed the hardcoded one. The builder has some defaults that should make it easy to change defaults if necessary, and it would be easier to add these as CLI args now.