### PR TITLE
feat: add cutoff param in active-nodes api

### DIFF
--- a/bins/api-server/src/peerdb/routes.rs
+++ b/bins/api-server/src/peerdb/routes.rs
@@ -1,15 +1,22 @@
 use super::app_state::AppState;
 use axum::{
-    extract::{Path, State},
+    extract::{Path, Query, State},
     routing::get,
     Json, Router,
 };
 use chrono::{Days, Utc};
 use reth_crawler_db::{types::ClientData, PeerDB, PeerData};
+use serde::Deserialize;
 use std::sync::Arc;
 
 /// The max `last_seen` a node can have and still be considered active (in DAYS).
-const MAX_LAST_SEEN: u64 = 5;
+const MAX_LAST_SEEN: u64 = 1;
+
+/// Cutoff parameter for letting a client choose the cutoff parameter on its own.
+#[derive(Deserialize)]
+struct CutoffParam {
+    cutoff: u64,
+}
 
 /// Router for all APIs.
 pub(crate) fn rest_router() -> Router<AppState> {
@@ -26,11 +33,20 @@ async fn get_nodes(State(store): State<Arc<dyn PeerDB>>) -> Json<Vec<PeerData>> 
     Json(store.all_peers(Some(50)).await.unwrap())
 }
 
-async fn get_active_nodes(State(store): State<Arc<dyn PeerDB>>) -> Json<Vec<PeerData>> {
-    let cutoff = Utc::now()
-        .checked_sub_days(Days::new(MAX_LAST_SEEN))
-        .expect("Data is not ouf of range")
-        .to_string();
+async fn get_active_nodes(
+    State(store): State<Arc<dyn PeerDB>>,
+    cutoff_param: Option<Query<CutoffParam>>,
+) -> Json<Vec<PeerData>> {
+    let cutoff = match cutoff_param {
+        Some(cutoffparam) => Utc::now()
+            .checked_sub_days(Days::new(cutoffparam.cutoff))
+            .expect("Data is not ouf of range")
+            .to_string(),
+        None => Utc::now()
+            .checked_sub_days(Days::new(MAX_LAST_SEEN))
+            .expect("Data is not ouf of range")
+            .to_string(),
+    };
     Json(store.all_active_peers(cutoff, Some(50)).await.unwrap())
 }
 
@@ -38,11 +54,20 @@ async fn get_clients(State(store): State<Arc<dyn PeerDB>>) -> Json<Vec<ClientDat
     Json(store.clients(Some(50)).await.unwrap())
 }
 
-async fn get_active_clients(State(store): State<Arc<dyn PeerDB>>) -> Json<Vec<ClientData>> {
-    let cutoff = Utc::now()
-        .checked_sub_days(Days::new(MAX_LAST_SEEN))
-        .expect("Data is not ouf of range")
-        .to_string();
+async fn get_active_clients(
+    State(store): State<Arc<dyn PeerDB>>,
+    cutoff_param: Option<Query<CutoffParam>>,
+) -> Json<Vec<ClientData>> {
+    let cutoff = match cutoff_param {
+        Some(cutoff) => Utc::now()
+            .checked_sub_days(Days::new(cutoff.cutoff))
+            .expect("Data is not ouf of range")
+            .to_string(),
+        None => Utc::now()
+            .checked_sub_days(Days::new(MAX_LAST_SEEN))
+            .expect("Data is not ouf of range")
+            .to_string(),
+    };
     Json(store.active_clients(cutoff, Some(50)).await.unwrap())
 }
 


### PR DESCRIPTION
Now everyone can add a query parameter in the `active-nodes` api so that it choose the cutoff parameter on its own.

Default is one day.

Example:

```bash
curl "http://0.0.0.0:3030/active-nodes?cutoff=100"
```